### PR TITLE
modified article endpoints to return aggregates and articles by batches

### DIFF
--- a/ddd/src/app/article/list.js
+++ b/ddd/src/app/article/list.js
@@ -20,13 +20,28 @@ module.exports = ({ articleRepository }) => {
           break;
       }
 
-      return await articleRepository.find(type, stage, filters);
+      return await articleRepository.aggregate(type, stage, filters);
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
+  const listByBatch = async batchId => {
+    try {
+      if (!batchId) {
+        return {
+          error: "A valid batchId is required"
+        };
+      }
+
+      return await articleRepository.findByBatch(batchId);
     } catch (error) {
       throw new Error(error);
     }
   };
 
   return {
-    list
+    list,
+    listByBatch
   };
 };

--- a/ddd/src/app/batch/create.js
+++ b/ddd/src/app/batch/create.js
@@ -1,5 +1,6 @@
 const Batch = require("src/domain/batch");
 const { hseArticle, sseArticle } = require("src/domain/article");
+const ObjectID = require("mongodb").ObjectID;
 
 const { parse } = require("./parse");
 const file = require("./file");
@@ -26,11 +27,12 @@ module.exports = ({ batchRepository, articleRepository, config }) => {
       const { getFile } = file({ config, type: batch.type });
       const csv = await getFile(batch.fileUrl);
       const articles = await parse(csv);
-      
+
       const result = articles.map(async article => {
-        article.batchId = newBatch._id;
+        article.batchId = new ObjectID(newBatch._id);
         article.published = new Date(batch.uploaded);
         article.harvested = new Date(batch.harvested);
+        article.status = "created";
 
         const entity =
           batch.type === "sse" ? sseArticle(article) : hseArticle(article);

--- a/ddd/src/domain/article/article.js
+++ b/ddd/src/domain/article/article.js
@@ -9,7 +9,7 @@ const Article = t.struct(
   {
     _id: t.maybe(t.String),
     legacyId: t.maybe(t.String),
-    batchId: t.maybe(tx.String.MongoId),
+    batchId: t.maybe(t.Object),
     shortId: t.String,
 
     title: t.String,
@@ -64,7 +64,8 @@ const Article = t.struct(
     translatedTitle: t.maybe(t.String),
     nameOfDatabase: t.maybe(t.String),
     databaseProvider: t.maybe(t.String),
-    stages: t.maybe(t.Object)
+    stages: t.maybe(t.Object),
+    status: t.maybe(t.String)
   },
   {
     defaultProps: {
@@ -73,6 +74,7 @@ const Article = t.struct(
       language: "English",
       complicated: false,
       lost: false,
+      status: "created",
       stages: {
         eligibility: { status: "pending_assignment" },
         studies: { status: "pending_assignment" },

--- a/ddd/src/infra/repositories/article/index.js
+++ b/ddd/src/infra/repositories/article/index.js
@@ -34,6 +34,28 @@ module.exports = ({ model }) => {
     }
   };
 
+  const findByBatch = async batchId => {
+    try {
+      const articles = await model.findByBatch(batchId);
+      return articles.map(article => {
+        return toEntity(article);
+      });
+    } catch (err) {
+      throw new Error(err);
+    }
+  };
+
+  const aggregate = async (type, stage, status) => {
+    try {
+      const articles = await model.aggregate(type, stage, status);
+      return articles.map(article => {
+        return article;
+      });
+    } catch (err) {
+      throw new Error(err);
+    }
+  };
+
   const create = async (...args) => {
     try {
       const article = await model.create(...args);
@@ -83,6 +105,8 @@ module.exports = ({ model }) => {
     update,
     findById,
     findByType,
+    findByBatch,
+    aggregate,
     find,
     assign,
     findOne

--- a/ddd/src/interfaces/http/modules/article/router.js
+++ b/ddd/src/interfaces/http/modules/article/router.js
@@ -149,9 +149,47 @@ module.exports = ({
    *         $ref: '#/responses/BadRequest'
    */
   router.get("/", (req, res) => {
-    const { type, stage, status } = req.query;
+    const { type, stage, status } = req.body;
     listUseCase
       .list(type, stage, status)
+      .then(data => {
+        res.status(Status.OK).json(Success(data));
+      })
+      .catch(error => {
+        logger.error(error); // we still need to log every error for debugging
+        res.status(Status.BAD_REQUEST).json(Fail(error.message));
+      });
+  });
+
+  /**
+   * @swagger
+   * /:
+   *   get:
+   *     tags:
+   *       - Article
+   *     description: Article list by batchId
+   *     consumes:
+   *       - application/json
+   *     produces:
+   *       - application/json
+   *     parameters:
+   *       - name: body
+   *         description: Article batchId
+   *         in: body
+   *         required: true
+   *         type: string
+   *         schema:
+   *           $ref: '#/definitions/article'
+   *     responses:
+   *       200:
+   *         description: Successfully created
+   *       400:
+   *         $ref: '#/responses/BadRequest'
+   */
+  router.get("/batch/:batchId", (req, res) => {
+    const { batchId } = req.params;
+    listUseCase
+      .listByBatch(batchId)
       .then(data => {
         res.status(Status.OK).json(Success(data));
       })


### PR DESCRIPTION
The regular get request for articles now returns the aggregate counts for the number of articles associated with the batch. I will update this to also include the other fields such as batch.name as well as assignments once complete.

http://localhost:5001/articles/
`{
  "success": true,
  "version": "",
  "date": "2020-03-10T03:42:21.817Z",
  "data": [
    {
      "_id": "5e670c923becf90bca37d7f4",
      "total": 98,
      "in_progress": 0,
      "complete": 0,
      "created": 98
    }
  ]
}`

I've created a new endpoint which allows articles to be queried by batchId.
This query returns a list of articles for that batch.

http://localhost:5001/articles/batch/5e670c923becf90bca37d7f4

