### PR TITLE
Tweak batches

### DIFF
--- a/ddd/src/app/batch/create.js
+++ b/ddd/src/app/batch/create.js
@@ -16,6 +16,13 @@ module.exports = ({ batchRepository, articleRepository, config }) => {
           error: "A valid batch type is required"
         };
       }
+
+      if (!batch.name) {
+        return {
+          error: "A valid batch name is required"
+        };
+      }
+
       // Create batch
       batch.uploaded = new Date();
       batch.harvested = new Date(batch.harvested);
@@ -30,6 +37,7 @@ module.exports = ({ batchRepository, articleRepository, config }) => {
 
       const result = articles.map(async article => {
         article.batchId = new ObjectID(newBatch._id);
+        article.batchName = batch.name;
         article.published = new Date(batch.uploaded);
         article.harvested = new Date(batch.harvested);
         article.status = "created";

--- a/ddd/src/app/eligibility/compare.js
+++ b/ddd/src/app/eligibility/compare.js
@@ -27,7 +27,7 @@ module.exports = ({ eligibilityRepository }) => {
 
       const filter = (path, key) =>
         path.length === 0 &&
-        [
+        ~[
           "_id",
           "shortId",
           "userId",
@@ -37,7 +37,7 @@ module.exports = ({ eligibilityRepository }) => {
         ].indexOf(key) < 0;
 
       const differences = diff(source, target, filter);
-      return differences.length;
+      return differences;
     } catch (error) {
       throw new Error(error);
     }

--- a/ddd/src/domain/article/article.js
+++ b/ddd/src/domain/article/article.js
@@ -10,6 +10,7 @@ const Article = t.struct(
     _id: t.maybe(t.String),
     legacyId: t.maybe(t.String),
     batchId: t.maybe(t.Object),
+    batchName: t.maybe(t.String),
     shortId: t.String,
 
     title: t.String,

--- a/ddd/src/domain/batch/batch.js
+++ b/ddd/src/domain/batch/batch.js
@@ -8,6 +8,7 @@ const Batch = t.struct(
     _id: t.maybe(t.String),
     // legacyId: t.String,
     shortId: t.String,
+    name: t.maybe(t.String),
 
     referenceType: t.maybe(t.String),
     fileName: t.maybe(t.String),

--- a/ddd/src/infra/database/models/article.js
+++ b/ddd/src/infra/database/models/article.js
@@ -97,7 +97,18 @@ module.exports = ({ database }) => {
                 $sum: {
                   $cond: [{ $eq: ["$status", "created"] }, 1, 0]
                 }
-              }
+              },
+              batchName: { $first: "$batchName" }
+            }
+          },
+          {
+            $project: {
+              _id: "$_id",
+              total: "$total",
+              in_progress: "$in_progress",
+              complete: "$complete",
+              created: "$created",
+              name: "$batchName"
             }
           }
         ])
@@ -197,6 +208,15 @@ module.exports = ({ database }) => {
       {
         $set: {
           status: "created"
+        }
+      },
+      { multi: true, upsert: true }
+    );
+    collection.updateMany(
+      { batchName: { $exists: false } },
+      {
+        $set: {
+          batchName: ""
         }
       },
       { multi: true, upsert: true }

--- a/ddd/src/infra/database/models/eligibility.js
+++ b/ddd/src/infra/database/models/eligibility.js
@@ -45,7 +45,7 @@ module.exports = ({ database }) => {
       return await database
         .get()
         .collection(COLLECTION)
-        .findOne(query)
+        .find(query)
         .toArray();
     } catch (e) {
       throw e;
@@ -91,10 +91,10 @@ module.exports = ({ database }) => {
   };
 
   const createIndexes = () => {
-    database
-      .get()
-      .collection(COLLECTION)
-      .createIndex("type");
+    const collection = database.get().collection(COLLECTION);
+    collection.createIndex("type");
+    collection.createIndex("articleId");
+    collection.createIndex("userId");
   };
 
   return {

--- a/ddd/src/interfaces/http/modules/eligibility/instance.js
+++ b/ddd/src/interfaces/http/modules/eligibility/instance.js
@@ -16,8 +16,7 @@ module.exports = () => {
   });
 
   const compareUseCase = compare({
-    eligibilityRepository,
-    articleRepository
+    eligibilityRepository
   });
 
   return {

--- a/ddd/src/interfaces/http/modules/eligibility/router.js
+++ b/ddd/src/interfaces/http/modules/eligibility/router.js
@@ -73,7 +73,7 @@ module.exports = ({
    *         $ref: '#/responses/BadRequest'
    */
   router.get("/:shortArticleId", (req, res) => {
-    const { userId } = req.query; 
+    const { userId } = req.query;
     const { shortArticleId } = req.params;
     getUseCase
       .get(shortArticleId, userId)
@@ -114,7 +114,7 @@ module.exports = ({
   router.get("/compare/:shortArticleId", (req, res) => {
     const { shortArticleId } = req.params;
     compareUseCase
-      .get(shortArticleId)
+      .compare(shortArticleId)
       .then(data => {
         res.status(Status.OK).json(Success(data));
       })


### PR DESCRIPTION
Fixed up eligibility comparison to return the diff instead of a boolean.
Example result of two entries with a single difference.

**Query**
```
GET http://localhost:5001/eligibility/compare/5e25413d480f66e7c2f8b7fa
```

**Result**
```
{
  "success": true,
  "version": "",
  "date": "2020-03-23T00:28:38.398Z",
  "data": [
    {
      "kind": "E",
      "path": [
        "government"
      ],
      "lhs": true,
      "rhs": false
    }
  ]
}
```